### PR TITLE
Extend stepper motor interface with method StepperMotor::isMoving

### DIFF
--- a/include/MotorControler.h
+++ b/include/MotorControler.h
@@ -70,6 +70,8 @@ namespace mtca4u
 
     virtual bool isEnabled()=0; ///< Check whether the motor driver chip is enabled
     
+    virtual bool isMotorMoving()=0; ///< check if the motor is moving.
+
     virtual MotorReferenceSwitchData getReferenceSwitchData()=0; ///< Get information about both reference switches of this Motor
 
     /** Enable or disable the positive reference switch. (true=enabled)*/

--- a/include/MotorControlerDummy.h
+++ b/include/MotorControlerDummy.h
@@ -94,6 +94,24 @@ namespace mtca4u{
     virtual double getUserCurrentLimit();
     virtual double getMaxCurrentLimit();
 
+    /**
+     * Block the motor and do not move if true. simulateBlockedMotor(true) is an
+     * alternative to calling moveTowardsTarget with the blockMotor flag set to
+     * true.
+     */
+    void simulateBlockedMotor(bool state);
+
+    /**
+     * Does the following:
+     * - Current, target and absolute positions reset to zero.
+     * - Both positive and negative end switches are enabled.
+     * - Sets the internal state _bothEndSwitchesAlwaysOn to false.
+     * - blockMotor status set to false.
+     */
+    void resetInternalStateToDefaults();
+
+    virtual bool isMotorMoving();
+
     static const int _positiveEndSwitchPosition; ///< Like the real position of the positive end switch in steps // TSK - make it public, needed for test
     static const int _negativeEndSwitchPosition; ///< Like the real position of the negative end switch in steps // TSK - make it public, needed for test
   private:
@@ -118,11 +136,6 @@ namespace mtca4u{
      *  be activated which was inactive before.
      */
     bool isStepping();
-
-    /** The motor is moving if it is stepping (see isStepping() ) and it is
-     *  enabled.
-     */
-    bool isMoving();
 
     bool isPositiveEndSwitchActive();
     bool isNegativeEndSwitchActive();

--- a/include/MotorControlerImpl.h
+++ b/include/MotorControlerImpl.h
@@ -103,7 +103,28 @@ namespace mtca4u
 
 
     bool isEnabled();
-    
+
+    /**
+     * @brief Returns True if the motor is in motion or False if at
+     * standstill. This command is reliable as long as the motor is not stalled.
+     *
+     * @details
+     * Motor status is decided by monitoring the Standstill indicator bit of the
+     * TMC260 driver IC. The standstill indicator bit can reliably track
+     * movement as long as the motor is not stalled. When movement has stalled,
+     * the controller IC still sends STEP pulses to the driver IC. As a result,
+     * for this situation, the Standstill indicator bit indicates movement
+     * though the motor is actually stalled and not moving. Once the controller
+     * chip has stopped with the STEP pulses, the stand still indicator
+     * concludes that the movement is complete.
+     *
+     * This method has a minimum internal delay of COMMUNICATION_DELAY before
+     * returning. This delay compensates for the time it takes for the
+     * standstill indicator bit to be updated after the X_TARGET register on the
+     * controller has been set.
+     */
+    virtual bool isMotorMoving();
+
     MotorReferenceSwitchData getReferenceSwitchData();
 
     void setPositiveReferenceSwitchEnabled(bool enableStatus);
@@ -145,6 +166,9 @@ namespace mtca4u
      unsigned int getReferenceSwitchBit();
  
   private:
+
+     static const unsigned int COMMUNICATION_DELAY= 20000; /// in microseconds
+
      boost::shared_ptr< Device > _device;
 
      unsigned int _id;

--- a/include/StepperMotor.h
+++ b/include/StepperMotor.h
@@ -67,7 +67,7 @@ namespace mtca4u {
         /**
          * @brief  Constructor of the class object
          * @param  motorDriverCardDeviceName Name of the device in DMAP file
-	 * @param  moduleName Name of the module in the map file (there might be more than one MD22 per device/ FMC carrier).
+         * @param  moduleName Name of the module in the map file (there might be more than one MD22 per device/ FMC carrier).
          * @param  motorDriverId Each Motor Card Driver has two independent Motor Drivers (can drive two physical motors). ID defines which motor should be represented by this class instantiation  
          * @param  motorDriverCardConfigFileName Name of configuration file
          * @return
@@ -116,7 +116,7 @@ namespace mtca4u {
          * Return real motor position read directly from the hardware and expressed in the arbitrary units.
          * Calculation between steps and arbitrary units is done internally.\n
          * @return float - current, real position of motor in arbitrary units.
-	 */     
+         */     
         float getCurrentPosition(); //old name: getMotorPosition
 
         /**
@@ -157,8 +157,15 @@ namespace mtca4u {
          * Function stop the motor in a way that real position from the motor is set as a target position.\n
          * It also interrupts all blocking functions as 'StepperMotorStatusAndError moveToPosition(float newPosition)'. \n
          * Delays in communication can trigger effect that motor will move a few steps in current movement direction and later will move couple steps back, but this issue can be filtered by motor hysteresis effect.\n
-         */  
+         */
         virtual void stop();
+
+        /**
+         * @brief Returns True if the motor is moving and false if at
+         * standstill. This command is reliable as long as the motor is not
+         * stalled.
+         */
+        bool isMoving();
 
         /**
          * @brief Emergency stop the motor by disabling driver.
@@ -227,9 +234,9 @@ namespace mtca4u {
          * method may not set the exact desired speed limit, but a value below
          * the desired limit, as determined by the operating parameters.
          *
-         * @param microStepsPerSecond The desired maximum motor speed during
-         *                            operation; unit is microsteps per
-         *                            second
+         * @param newSpeedInUstepsPerSec The desired maximum motor speed during
+         *                               operation; unit is microsteps per
+         *                               second
          *
          * @return Returns the motor speed that was actually set. This speed may not
          * be what the user requested, but a value closest to it (but not

--- a/src/LinearStepperMotor.cc
+++ b/src/LinearStepperMotor.cc
@@ -26,72 +26,33 @@ namespace mtca4u {
     // BLOCKING FUNCTIONS
     // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-    LinearStepperMotorStatusAndError LinearStepperMotor::moveToPosition(float newPosition) {
+    LinearStepperMotorStatusAndError LinearStepperMotor::moveToPosition(
+        float newPosition) {
 
-        LinearStepperMotorStatusAndError statusAndError;
+      LinearStepperMotorStatusAndError statusAndError;
+      statusAndError = this->determineMotorStatusAndError();
 
-        statusAndError = this->determineMotorStatusAndError();
-        if (getCurrentPosition() == newPosition) {
-            return statusAndError;
-        }
-
-        if (statusAndError.status == StepperMotorStatusTypes::M_ERROR || statusAndError.status == StepperMotorStatusTypes::M_DISABLED) {
-            return statusAndError;
-        }
-
-        _blockingFunctionActive = true;
-        this->setTargetPosition(newPosition);
-
-        if (!this->getAutostart()) {
-            this->start();
-        }
-
-        bool continueWaiting = true;
-        unsigned int notInPositionCounter = 0;
-        do {
-            statusAndError = this->determineMotorStatusAndError();
-            _logger(Logger::FULL_DETAIL) << "LinearStepperMotor::moveToPosition : Motor in move. Current position: " << this->getCurrentPosition() << ". Target position: " << _targetPositionInSteps << ". Current status: " << _motorStatus << std::endl;
-
-            int currentMotorPosition = _motorControler->getActualPosition();
-
-            if (statusAndError.status == LinearStepperMotorStatusTypes::M_ERROR) {
-                return statusAndError;
-            }
-
-            if (_stopMotorForBlocking == true) {
-                continueWaiting = false;
-                _stopMotorForBlocking = false;
-                _logger(Logger::WARNING) << "LinearStepperMotor::moveToPosition : Motor stopped by user." << std::endl;
-                while (statusAndError.status == LinearStepperMotorStatusTypes::M_IN_MOVE || statusAndError.status == LinearStepperMotorStatusTypes::M_NOT_IN_POSITION) {
-                    _logger(Logger::DETAIL) << "LinearStepperMotor::moveToPosition : Wait to change status from M_IN_MOVE/M_NOT_IN_POSITION to other." << std::endl;
-                    statusAndError = this->determineMotorStatusAndError();
-                }
-            } else if (statusAndError.status == LinearStepperMotorStatusTypes::M_NEGATIVE_END_SWITCHED_ON && _targetPositionInSteps > currentMotorPosition) {
-                continueWaiting = true;
-                _logger(Logger::DETAIL) << "LinearStepperMotor::moveToPosition : Negative end switch on but moving in positive direction. Current position: " << getCurrentPosition() << std::endl;
-            } else if (statusAndError.status == LinearStepperMotorStatusTypes::M_POSITIVE_END_SWITCHED_ON && _targetPositionInSteps < currentMotorPosition) {
-                continueWaiting = true;
-                _logger(Logger::DETAIL) << "LinearStepperMotor::moveToPosition : Positive end switch on but moving in negative direction. Current position: " << getCurrentPosition() << std::endl;
-            } else if (statusAndError.status == mtca4u::LinearStepperMotorStatusTypes::M_IN_MOVE || statusAndError.status == LinearStepperMotorStatusTypes::M_NOT_IN_POSITION) {
-                continueWaiting = true;
-                if (statusAndError.status == LinearStepperMotorStatusTypes::M_NOT_IN_POSITION) {
-                    notInPositionCounter++;
-                    usleep(1000);
-                    if (currentMotorPosition == _motorControler->getActualPosition() && notInPositionCounter > 1000) {
-                        _logger(Logger::ERROR) << "LinearStepperMotor::moveToPosition(float) : Motor seems not to move after 1 second waiting. Current position. " << getCurrentPosition() << std::endl;
-                        statusAndError.status = static_cast<LinearStepperMotorStatus> (LinearStepperMotorStatusTypes::M_ERROR);
-                        statusAndError.error = static_cast<LinearStepperMotorError> (LinearStepperMotorErrorTypes::M_NO_REACTION_ON_COMMAND);
-                        continueWaiting = false;
-                    }
-                } else {
-                    notInPositionCounter = 0;
-                }
-            } else {
-                continueWaiting = false;
-            }
-        } while (continueWaiting);
-
+      if (statusAndError.status == StepperMotorStatusTypes::M_ERROR ||
+          statusAndError.status == StepperMotorStatusTypes::M_DISABLED) {
         return statusAndError;
+      }
+
+      _blockingFunctionActive = true;
+
+      // Ask the hardware to move the motor.
+      this->setTargetPosition(newPosition);
+      if (!this->getAutostart()) {
+          this->start();
+      }
+
+      // Block till the motor has finished moving.
+      while (StepperMotor::isMoving()){
+          usleep(1000);
+      }
+
+      // update and return status and error once at target position.
+      _blockingFunctionActive = false;
+      return(this->determineMotorStatusAndError());
     }
 
     StepperMotorCalibrationStatus LinearStepperMotor::calibrateMotor() {
@@ -210,10 +171,11 @@ namespace mtca4u {
     }
 
     void LinearStepperMotor::emergencyStop() {
-        _motorControler->setEnabled(false);
-        this->stop();
-        if (this->_motorCalibrationStatus == StepperMotorCalibrationStatusType::M_CALIBRATED)
-            this->_motorCalibrationStatus = StepperMotorCalibrationStatusType::M_NOT_CALIBRATED;
+      _motorControler->setEnabled(false);
+      this->stop();
+      // emergency stop causes loss in calibration for all situations
+      this->_motorCalibrationStatus =
+          StepperMotorCalibrationStatusType::M_NOT_CALIBRATED;
     }
 
     // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/src/MotorControlerDummy.cc
+++ b/src/MotorControlerDummy.cc
@@ -25,14 +25,14 @@ namespace mtca4u {
     int MotorControlerDummy::getActualVelocity() {
         // the velocity is only not zero if the motor is actually moving
         // FIXME: or if the motor is stepping?
-        if (isMoving()) {
+        if (isMotorMoving()) {
             return ( _targetPosition < _currentPosition ? -25 : 25);
         } else {
             return 0;
         }
     }
 
-    bool MotorControlerDummy::isMoving() {
+    bool MotorControlerDummy::isMotorMoving() {
         return (_enabled && isStepping());
     }
 
@@ -76,7 +76,7 @@ namespace mtca4u {
 
     DriverStatusData MotorControlerDummy::getStatus() {
         DriverStatusData statusData;
-        statusData.setStandstillIndicator(!isMoving());
+        statusData.setStandstillIndicator(!isMotorMoving());
         return statusData;
     }
 
@@ -232,6 +232,16 @@ namespace mtca4u {
       throw MotorDriverException("MotorControlerDummy::getMaxCurrentLimit() is not implemented yet!", MotorDriverException::NOT_IMPLEMENTED);
     }
 
+    void MotorControlerDummy::resetInternalStateToDefaults() {
+      _absolutePosition = 0;
+      _targetPosition = 0;
+      _currentPosition = 0;
+      _positiveEndSwitchEnabled = true;
+      _negativeEndSwitchEnabled = true;
+      _bothEndSwitchesAlwaysOn = false;
+      _blockMotor = false;
+  }
+
 
     bool MotorControlerDummy::isNegativeEndSwitchActive() {
         if (_bothEndSwitchesAlwaysOn)
@@ -306,4 +316,8 @@ namespace mtca4u {
         _currentPosition = targetInThisMove;
     }
 
-}// namespace mtca4u
+    void MotorControlerDummy::simulateBlockedMotor(bool state) {
+      _blockMotor = state;
+    }
+    } // namespace mtca4u
+

--- a/src/MotorControlerImpl.cc
+++ b/src/MotorControlerImpl.cc
@@ -189,12 +189,14 @@ namespace mtca4u
   DEFINE_GET_SET_VALUE( PositionTolerance, IDX_DELTA_X_REFERENCE_TOLERANCE )
   DEFINE_GET_SET_VALUE( PositionLatched, IDX_POSITION_LATCHED )
 
-  unsigned int MotorControlerImpl::getMaximumVelocity (){
-      return _controlerSPI->read( _id, IDX_MAXIMUM_VELOCITY ).getDATA();}
+  unsigned int MotorControlerImpl::getMaximumVelocity() {
+    return _controlerSPI->read(_id, IDX_MAXIMUM_VELOCITY).getDATA();
+  }
 
-    void MotorControlerImpl::setMaximumVelocity (unsigned int value){
-      _currentVmax = value;
-      _controlerSPI->write( _id, IDX_MAXIMUM_VELOCITY, value );}
+  void MotorControlerImpl::setMaximumVelocity(unsigned int value) {
+    _currentVmax = value;
+    _controlerSPI->write(_id, IDX_MAXIMUM_VELOCITY, value);
+  }
 
   template<class T>
   T  MotorControlerImpl::readTypedRegister(){
@@ -375,6 +377,17 @@ namespace mtca4u
     if(calculatedCurrentScale < iMaxTMC260C_MIN_CURRENT_SCALE_VALUE){return iMaxTMC260C_MIN_CURRENT_SCALE_VALUE;}
     if(calculatedCurrentScale > hardLimitForCurrentScale){return hardLimitForCurrentScale;}
     return (static_cast<unsigned int>(std::floor(calculatedCurrentScale))); //floor so that we dont exceed the set limt
+  }
+
+  bool MotorControlerImpl::isMotorMoving() {
+    // There is a delay between setting X_Target and the standstill indicator
+    // bit updating to 0 to indicate this. Reading the standstill indicator bit
+    // before this delay, incorrectly returns standstill indicator value as 1.
+    // To make sure we don't run into this situation, fetch the standstill
+    // indicator only after the time it takes for the indicator bit to update
+    // its value.
+    usleep(COMMUNICATION_DELAY);
+    return (!(getStatus().getStandstillIndicator()));
   }
 
   void MotorControlerImpl::setCurrentScale(unsigned int currentScale) {

--- a/src/StepperMotor.cc
+++ b/src/StepperMotor.cc
@@ -41,7 +41,7 @@ namespace mtca4u {
         _blockingFunctionActive = false;
 
         _softwareLimitsEnabled = true;
-        _motorCalibrationStatus = StepperMotorCalibrationStatusType::M_CALIBRATION_UNKNOWN;
+        _motorCalibrationStatus = StepperMotorCalibrationStatusType::M_NOT_CALIBRATED;
     }
 
     StepperMotor::~StepperMotor() {
@@ -120,22 +120,25 @@ namespace mtca4u {
         return _motorCalibrationStatus;
     }
 
-    // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     // END OF BLOCKING FUNCTIONS
-    // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-    // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     // GENERAL FUNCTIONS
-    // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
     void StepperMotor::start() {
-        // allowing it when status is MOTOR_IN_MOVE give a possibility to change target position during motor movement
-        _motorControler->setTargetPosition(_targetPositionInSteps);
+      // allowing it when status is MOTOR_IN_MOVE give a possibility to change
+      // target position during motor movement
+      _motorControler->setTargetPosition(_targetPositionInSteps);
     }
 
     void StepperMotor::stop() {
-        //stopping is done by reading real position and setting it as target one. In reality it can cause that motor will stop and move in reverse direction by couple steps
-        //Amount of steps done in reverse direction depends on motor speed and general delay in motor control path
+        //stopping is done by reading real position and setting it as target
+        //one. In reality it can cause that motor will stop and move in reverse
+        //direction by couple steps Amount of steps done in reverse direction
+        //depends on motor speed and general delay in motor control path.
 
         if (_blockingFunctionActive)
             _stopMotorForBlocking = true;
@@ -208,7 +211,6 @@ namespace mtca4u {
 
     void StepperMotor::setTargetPosition(float newPosition) {
         this->determineMotorStatusAndError();
-
         if (_motorError == StepperMotorErrorTypes::M_NO_ERROR) {
             float position = truncateMotorPosition(newPosition);
             _targetPositionInUnits = position;
@@ -387,5 +389,8 @@ namespace mtca4u {
 
         return StepperMotorStatusAndError(_motorStatus, _motorError);
     }
-    
-}
+    }
+
+    bool mtca4u::StepperMotor::isMoving() {
+      return (_motorControler->isMotorMoving());
+    }

--- a/tests/src/testStepperMotor.cpp
+++ b/tests/src/testStepperMotor.cpp
@@ -403,7 +403,7 @@ void StepperMotorTest::testDebugLevel() {
 }
 
 void StepperMotorTest::testCalibration() {
-    BOOST_CHECK(_stepperMotor->getCalibrationStatus() == StepperMotorCalibrationStatusType::M_CALIBRATION_UNKNOWN);
+    BOOST_CHECK(_stepperMotor->getCalibrationStatus() == StepperMotorCalibrationStatusType::M_NOT_CALIBRATED);
     _stepperMotor->calibrateMotor();
     BOOST_CHECK(_stepperMotor->getCalibrationStatus() == StepperMotorCalibrationStatusType::M_CALIBRATION_NOT_AVAILABLE);
 }
@@ -470,15 +470,19 @@ void StepperMotorTest::testMoveToPosition() {
     _stepperMotor->setSoftwareLimitsEnabled(false);
     
     
-    //trigger internal error during movement
-    //std::cout << "Status main 1 " << _stepperMotor->getStatusAndError().status << " Error main " << _stepperMotor->getStatusAndError().error<< " POS: "<<_motorControlerDummy->getActualPosition()  << std::endl;
-    //BOOST_CHECK(statusAndError.status == StepperMotorStatusTypes::M_ERROR);
-    boost::thread workedThread1(&StepperMotorTest::thread, this, 1);
-    statusAndError = _stepperMotor->moveToPosition(0);
-    //std::cout << "Status main 2 " << statusAndError.status  << " Error main " << statusAndError.error << " POS: "<<_motorControlerDummy->getActualPosition()  << std::endl;
-    BOOST_CHECK(statusAndError.status == StepperMotorStatusTypes::M_ERROR);
-    BOOST_CHECK(statusAndError.error == StepperMotorErrorTypes::M_CONFIG_ERROR_MIN_POS_GRATER_EQUAL_TO_MAX);
-    workedThread1.join();
+
+    auto currentPosition = _stepperMotor->getCurrentPosition();
+    _stepperMotor->setMaxPositionLimit(currentPosition - 100);
+    _stepperMotor->setMinPositionLimit(currentPosition - 200);
+    _stepperMotor->setSoftwareLimitsEnabled(true);
+    boost::thread workerThread1(&StepperMotorTest::thread, this, 1);
+    statusAndError = _stepperMotor->moveToPosition(currentPosition + 100);
+    workerThread1.join();
+    BOOST_CHECK(statusAndError.status == StepperMotorStatusTypes::M_SOFT_POSITIVE_END_SWITCHED_ON);
+    BOOST_CHECK(statusAndError.error == StepperMotorErrorTypes::M_NO_ERROR);
+    BOOST_CHECK(_motorControlerDummy->getTargetPosition() == currentPosition - 100);
+    _stepperMotor->setSoftwareLimitsEnabled(false);
+
     
     //test stop blocking function
     boost::thread workedThread2(&StepperMotorTest::thread, this, 2);
@@ -487,19 +491,16 @@ void StepperMotorTest::testMoveToPosition() {
     BOOST_CHECK(statusAndError.status == StepperMotorStatusTypes::M_OK);
     BOOST_CHECK(statusAndError.error == StepperMotorErrorTypes::M_NO_ERROR);
     BOOST_CHECK(_stepperMotor->getCurrentPosition() != targerPosition);
-    //std::cout << "Status main 2 " << statusAndError.status  << " Error main " << statusAndError.error << " POS: "<<_motorControlerDummy->getActualPosition()  << std::endl;
     workedThread2.join();    
     
     
     //test when we will succesfully finish movement
-    //_stepperMotor->setLogLevel(Logger::FULL_DETAIL);
     targerPosition = _motorControlerDummy->getActualPosition() + 3000;
-    boost::thread workedThread3_1(&StepperMotorTest::thread, this, 3);
+    boost::thread workedThread3_1(&StepperMotorTest::thread, this, 1);
     statusAndError = _stepperMotor->moveToPosition(targerPosition);
     BOOST_CHECK(statusAndError.status == StepperMotorStatusTypes::M_OK);
     BOOST_CHECK(statusAndError.error == StepperMotorErrorTypes::M_NO_ERROR);
     BOOST_CHECK(_stepperMotor->getCurrentPosition() == targerPosition);
-    //std::cout << "Status main 2 " << statusAndError.status  << " Error main " << statusAndError.error << " POS: "<<_motorControlerDummy->getActualPosition()  << std::endl;
     workedThread3_1.join(); 
     
     
@@ -507,67 +508,37 @@ void StepperMotorTest::testMoveToPosition() {
     //test when we will succesfully finish movement but with autostart ON
     _stepperMotor->setAutostart(true);
     targerPosition = _motorControlerDummy->getActualPosition() + 3000;
-    boost::thread workedThread3_2(&StepperMotorTest::thread, this, 3);
+    boost::thread workedThread3_2(&StepperMotorTest::thread, this, 1);
     statusAndError = _stepperMotor->moveToPosition(targerPosition);
     BOOST_CHECK(statusAndError.status == StepperMotorStatusTypes::M_OK);
     BOOST_CHECK(statusAndError.error == StepperMotorErrorTypes::M_NO_ERROR);
     BOOST_CHECK(_stepperMotor->getCurrentPosition() == targerPosition);
     _stepperMotor->setAutostart(false);
-    //std::cout << "Status main 2 " << statusAndError.status  << " Error main " << statusAndError.error << " POS: "<<_motorControlerDummy->getActualPosition()  << std::endl;
     workedThread3_2.join(); 
     
 }
 
 void StepperMotorTest::thread(int testCase) {
 
+  if (testCase == 1) {
     
-    if (testCase == 1) {
-        //std::cout << "Status " << _stepperMotor->getStatusAndError().status << " Error " << _stepperMotor->getStatusAndError().error << std::endl;
-        //sleep between thread start and first command to give time for run moveToPosition
-        usleep(10000);
-        // simulate the movement
-        _motorControlerDummy->moveTowardsTarget(0.4, false);
-        //std::cout << "Status " << _stepperMotor->getStatusAndError().status << " Error " << _stepperMotor->getStatusAndError().error << std::endl;
-        usleep(10000);
-        //change condition to simulate error
-        _stepperMotor->setSoftwareLimitsEnabled(true);
-        //std::cout << "Status " << _stepperMotor->getStatusAndError().status << " Error " << _stepperMotor->getStatusAndError().error << std::endl;
-        //sleep to give time to react on error
-        usleep(50000);
-        //std::cout << "Status " << _stepperMotor->getStatusAndError().status << " Error " << _stepperMotor->getStatusAndError().error << std::endl;
-        //disable the configuration error
-        _stepperMotor->setSoftwareLimitsEnabled(false);
-        //std::cout << "Status " << _stepperMotor->getStatusAndError().status << " Error " << _stepperMotor->getStatusAndError().error << std::endl;
+    // do not proceed till the parent thread has asked the moter to move
+    if (_stepperMotor->isMoving() != false) {
+      usleep(10000);
     }
-    
-    if (testCase == 2) {
-        //sleep between thread start and first command to give time for run moveToPosition
-        usleep(10000);
-        // simulate the movement
-        _motorControlerDummy->moveTowardsTarget(0.4, false);
-        usleep(10000);
-        _stepperMotor->stop();
-        usleep(50000);
-    }
+    // simulate the movement
+    _motorControlerDummy->moveTowardsTarget(1);
+  }
 
-    if (testCase == 3) {
-        //sleep between thread start and first command to give time for run moveToPosition
-        usleep(10000);
-        // simulate the movement
-        _motorControlerDummy->moveTowardsTarget(0.2, false);
-        usleep(10000);
-        _motorControlerDummy->moveTowardsTarget(0.4, false);
-        usleep(10000);
-        _motorControlerDummy->moveTowardsTarget(0.6, false);
-        usleep(10000);
-        _motorControlerDummy->moveTowardsTarget(0.8, false);
-        usleep(10000);
-        _motorControlerDummy->moveTowardsTarget(1, false);
-        //std::cout << "Status " << _stepperMotor->getStatusAndError().status << " Error " << _stepperMotor->getStatusAndError().error << std::endl;
-        usleep(10000);
+  if (testCase == 2) {
+    // do not proceed till the parent thread has asked the moter to move
+    if (_stepperMotor->isMoving() != false) {
+      usleep(10000);
     }
-    
-    
+    // simulate the movement
+    _motorControlerDummy->moveTowardsTarget(0.4);
+    _stepperMotor->stop();
+  }
 }
 
 void StepperMotorTest::testUnitConverter() {


### PR DESCRIPTION
- Implements StepperMotor::isMoving
- Changes test cases in testLinearStepperMotor and testStepperMotor to
  prevent failures due to timing issues.