### PR TITLE
fix: BOTH_ENDSWITCHES_ON stays after calibration

### DIFF
--- a/steppermotor/src/LinearStepperMotor.cc
+++ b/steppermotor/src/LinearStepperMotor.cc
@@ -240,6 +240,13 @@ namespace ChimeraTK { namespace MotorDriver {
       _errorMode.exchange(Error::BOTH_END_SWITCHES_ON);
       _stateMachine->setAndProcessUserEvent(StateMachine::errorEvent);
     }
+    else {
+      // The error mode was BOTH_END_SWITCHES_ON, reset the error mode. Otherwise this will stick unless the application
+      // is re-started.
+      auto expected = Error::BOTH_END_SWITCHES_ON;
+      auto replace = Error::NO_ERROR;
+      _errorMode.compare_exchange_strong(expected, replace);
+    }
 
     if(_toleranceCalculated) {
       if(posActive) {


### PR DESCRIPTION
Scenario: Device comes up directly after power on with
BOTH_ENDSWITCHES_ENABLED. User starts calibration sequence, but
BOTH_ENDSWITCHES_ENABLED error keeps being shown in application until
application is re-started
