### PR TITLE
fix(project-template): Fix FindMako

### DIFF
--- a/cmake/Modules/FindMako.cmake
+++ b/cmake/Modules/FindMako.cmake
@@ -1,4 +1,13 @@
 # First check for python executable
+if(Python_EXECUTABLE)
+    set(PYTHON_EXECUTABLE ${Python_EXECUTABLE})
+endif()
+
+if(Python3_EXECUTABLE)
+    set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
+endif()
+
+
 if(NOT PYTHON_EXECUTABLE)
   find_program(PYTHON_EXECUTABLE python)
   if(NOT PYTHON_EXECUTABLE)


### PR DESCRIPTION
Apparently this now fails, because a) FindPython sets Python_EXECUTABLE
instead of PYTHON_EXECUTABLE, FindPython3 sets Python3_EXECUTABLE
and b) on some distributions there is no "python" binary that make
the fall-back in FindMake.cmake then fail
